### PR TITLE
Implement CI (right version of node and yarn)

### DIFF
--- a/.github/workflows/specs.yml
+++ b/.github/workflows/specs.yml
@@ -5,30 +5,23 @@ on:
   - workflow_dispatch
 
 jobs:
-  # TODO: Environment variables?
   build:
-    runs-on: '${{ matrix.os }}'
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         os:
-          - ubuntu-18.04
+          - ubuntu-22.04
+    env:
+      RAILS_MASTER_KEY: ${{ secrets.RAILS_MASTER_KEY }}
     steps:
-      - name: Cache multiple paths
-        uses: actions/cache@v2
-        with:
-          path: |-
-            node_modules
-            vendor/bundle
-          key: '${{ runner.os }}-${{ hashFiles(''TODO'') }}'
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v3
         with:
-          node-version: 12.13.1
+          node-version: '12.13.1' # Your Node.js version
       - uses: ruby/setup-ruby@v1
         with:
-          bundler-cache: true # runs 'bundle install' and caches installed gems automatically
-      - run: gem install bundler:2.1.4
-      - run: npm install -g yarn@1.22.4
+          bundler-cache: true # Automatically runs 'bundle install' and caches gems
+      - run: npm install -g yarn@1.22.4 # Your Yarn version
       - run: bundle install
       - run: yarn install
       - run: bundle exec rake db:setup

--- a/.github/workflows/specs.yml
+++ b/.github/workflows/specs.yml
@@ -17,11 +17,11 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v3
         with:
-          node-version: '12.13.1' # Your Node.js version
+          node-version: '13.14.0' 
       - uses: ruby/setup-ruby@v1
         with:
           bundler-cache: true # Automatically runs 'bundle install' and caches gems
-      - run: npm install -g yarn@1.22.4 # Your Yarn version
+      - run: npm install -g yarn@1.19.1 # Your Yarn version
       - run: bundle install
       - run: yarn install
       - run: bundle exec rake db:setup

--- a/README.md
+++ b/README.md
@@ -16,3 +16,5 @@ political events in their area as well as aggregate, share and view news items i
 ### Getting Setup Locally
 
 Follow the [Getting Started Guide](./docs/01-getting-started.md) to get your localhost environment setup.
+
+[![All Specs](https://github.com/cs169/fa23-chips-10.5-20/actions/workflows/specs.yml/badge.svg)](https://github.com/cs169/fa23-chips-10.5-20/actions/workflows/specs.yml)


### PR DESCRIPTION
I have filled the workflows/specs.yml. Especially for the node & yarn version, we should enter `nvm use 13` first before getting their version.